### PR TITLE
Fix room id resolution

### DIFF
--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -36,10 +36,17 @@ class RocketChatDriver
 		return r.updated
 
 	sendMessage: (text, roomid) =>
-		@logger.info "Sending Message To Room: #{roomid}"
 
-		@asteroid.call('sendMessage', {msg: text, rid: roomid})
-		
+		r = @getRoomId roomid
+
+		r.then ((result) =>
+
+			@logger.info "Sending Message To Room: #{roomid} (#{result})"
+
+			@asteroid.call('sendMessage', {msg: text, rid: result})
+
+		)
+
 	customMessage: (message) =>
 		@logger.info "Sending Custom Message To Room: #{message.channel}"
 


### PR DESCRIPTION
Add room resolution on `sendMessage` rocketchat driver method.
When using third party script (e.g. https://www.npmjs.com/package/hubot-gitlab-hooks), giving room name as query param on webhooks dont work, you must provide room internal ID.
